### PR TITLE
Restrict node version to >18.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,5 +133,8 @@
         "*.{json,js,ts,jsx,tsx,html}": [
             "prettier --check --write"
         ]
+    },
+    "engines": {
+        "node": ">=18.16"
     }
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -17,7 +17,7 @@ export const AVAILABLE_COLLATERAL_TRESHOLD = utils.parseUnits('5000', 8);
 export const MAX_UINT_AMOUNT =
     '115792089237316195423570985008687907853269984665640564039457584007913129639935';
 
-// Network Assets
+// Network Assets, TODO: Remove these since they are on sdk
 export const AVAILABLE_ASSETS: Record<string, { symbol: string; rewardSource?: string }[]> = {
     sepolia: [
         { symbol: 'AAVE' },


### PR DESCRIPTION
Lets try to use upgraded software. 

Needed because the monorepo side needs >18.16 since it uses the fetch API.

I confirmed that the build still works and yarn start works as expected. We can easily revert this commit if it breaks anything