### PR TITLE
Mel0n/fix vevmex

### DIFF
--- a/src/hooks/token.ts
+++ b/src/hooks/token.ts
@@ -172,22 +172,6 @@ export const useToken = (clearInputs?: () => void) => {
             ],
         });
 
-        // Get user pool rewards
-        const dvmexRewardsContract = new ethers.Contract(
-            '0xC4F1050a3216b116a78133038912BC3b9506aEF0',
-            VMEX_REWARD_POOL_ABI,
-            signer?.provider,
-        );
-        const vevmexRewardsContract = new ethers.Contract(
-            '0xecF3e854D428074d116DE6f31213522F6525Cf81',
-            VMEX_REWARD_POOL_ABI,
-            signer?.provider,
-        );
-        let [boostRewards, exitRewards] = await Promise.all([
-            dvmexRewardsContract.call.claim(),
-            vevmexRewardsContract.call.claim(),
-        ]);
-
         const now = Math.floor(Date.now() / 1000);
         let penalty = 0;
         if (end.gt(now)) {
@@ -225,8 +209,6 @@ export const useToken = (clearInputs?: () => void) => {
                         ? amount
                         : BigNumber.from(0),
             },
-            boostRewards: toNormalizedBN(boostRewards ?? BigNumber.from(0)),
-            exitRewards: toNormalizedBN(exitRewards ?? BigNumber.from(0)),
             exitPreview,
             penalty,
         };

--- a/src/ui/tables/gauges/custom-row.tsx
+++ b/src/ui/tables/gauges/custom-row.tsx
@@ -175,7 +175,11 @@ export const GaugesCustomRow = (props: IVaultAsset & { loading?: boolean }) => {
                 </td>
                 <td className="pl-4 pr-1">
                     <Loader loading={loading}>
-                        {gaugeAPR ? percentFormatter.format(gaugeAPR) : '-'}
+                        {gaugeAPR
+                            ? `${percentFormatter.format(gaugeAPR / 10)}` +
+                              '-' +
+                              `${percentFormatter.format(gaugeAPR)}`
+                            : '-'}
                     </Loader>
                 </td>
                 {/* <td className="pl-4">


### PR DESCRIPTION
Drive by Changes: 

- Fixed veVMEX not showing for users, problem was contract being called incorrectly, we had a doubling up of the ethers call where one was left over from before and resulted in an undefined call 
- added gauge apr range to show complete range from 10% rewards to fully boosted 10x rewards (assuming the apr before was 10x, which I think it is).

  